### PR TITLE
Add lightweight desktop UI, with tray icon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
           </descriptorRefs>
           <archive>
             <manifest>
-              <mainClass>brs.Burst</mainClass>
+              <mainClass>brs.BurstGUI</mainClass>
             </manifest>
           </archive>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
           </descriptorRefs>
           <archive>
             <manifest>
-              <mainClass>brs.BurstGUI</mainClass>
+              <mainClass>brs.BurstLauncher</mainClass>
             </manifest>
           </archive>
         </configuration>

--- a/src/brs/BurstGUI.java
+++ b/src/brs/BurstGUI.java
@@ -1,0 +1,308 @@
+package brs;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.TextArea;
+import javafx.stage.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.io.*;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.Permission;
+
+public class BurstGUI extends Application {
+    private static String[] args;
+    private static boolean userClosed = false;
+    private static final Logger LOGGER = LoggerFactory.getLogger(BurstGUI.class);
+    private static Stage stage;
+    private static TrayIcon trayIcon = null;
+
+    public static void main(String[] args) {
+        BurstGUI.args = args;
+        addToClasspath("./conf");
+        System.setSecurityManager(new BurstGUISecurityManager());
+        Platform.setImplicitExit(false);
+        launch(args);
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+        primaryStage.setTitle("Burst Reference Software version " + Burst.VERSION);
+        TextArea textArea = new TextArea();
+        textArea.setEditable(false);
+        sendJavaOutputToTextArea(textArea);
+        primaryStage.setScene(new Scene(textArea, 800, 450));
+        stage = primaryStage;
+        showTrayIcon();
+        new Thread(BurstGUI::runBrs).start();
+    }
+
+    /**
+     * Adds a path to add to the classpath
+     * @param s The path to add to the classpath
+     */
+    public static void addToClasspath(String s) {
+        try {
+            File f = new File(s);
+            URI u = f.toURI();
+            URLClassLoader urlClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+            Class<URLClassLoader> urlClass = URLClassLoader.class;
+            Method method = urlClass.getDeclaredMethod("addURL", URL.class);
+            method.setAccessible(true);
+            method.invoke(urlClassLoader, u.toURL());
+        } catch (Exception e) {
+            LOGGER.error("Could not add path \"" + s + "\" to classpath", e);
+        }
+    }
+
+    private static void shutdown() {
+        userClosed = true;
+        if (trayIcon != null && SystemTray.isSupported()) {
+            SystemTray.getSystemTray().remove(trayIcon);
+        }
+        System.exit(0); // BRS shutdown handled by exit hook
+    }
+
+    private static void showTrayIcon() {
+        if (trayIcon == null) { // Don't start running in tray twice
+            trayIcon = createTrayIcon();
+            if (trayIcon != null) {
+                stage.setOnCloseRequest(event -> hideWindow());
+            } else {
+                stage.show();
+                stage.setOnCloseRequest(event -> shutdown());
+            }
+        }
+    }
+
+    /**
+     * @return A tray icon if successful or null otherwise
+     */
+    private static TrayIcon createTrayIcon() {
+        try {
+            SystemTray systemTray = SystemTray.getSystemTray();
+            PopupMenu popupMenu = new PopupMenu();
+
+            MenuItem openWebUiButton = new MenuItem("Open Web GUI");
+            MenuItem showItem = new MenuItem("Show BRS output");
+            MenuItem shutdownItem = new MenuItem("Shutdown BRS");
+
+            openWebUiButton.addActionListener(e -> openWebUi());
+            showItem.addActionListener(e -> showWindow());
+            shutdownItem.addActionListener(e -> shutdown());
+
+            popupMenu.add(openWebUiButton);
+            popupMenu.add(showItem);
+            popupMenu.add(shutdownItem);
+
+            TrayIcon newTrayIcon = new TrayIcon(ImageIO.read(BurstGUI.class.getResourceAsStream("/images/burst_overlay_logo.png")), "Burst Reference Software", popupMenu);
+            newTrayIcon.setImage(newTrayIcon.getImage().getScaledInstance(newTrayIcon.getSize().width, -1, Image.SCALE_SMOOTH));
+            newTrayIcon.addActionListener(e -> openWebUi());
+            systemTray.add(newTrayIcon);
+            return newTrayIcon;
+        } catch (Exception e) {
+            LOGGER.error("Could not create tray icon", e);
+            return null;
+        }
+    }
+
+    private static void showWindow() {
+        Platform.runLater(stage::show);
+    }
+
+    private static void hideWindow() {
+        Platform.runLater(stage::hide);
+    }
+
+    private static void openWebUi() {
+        try {
+            Desktop.getDesktop().browse(new URI("http://localhost:8125"));
+        } catch (Exception e) {
+            showMessage("Error opening web UI. Please open your browser and navigate to \"http://localhost:8125\" or \"https://localhost:8125\" if the node is configured to use SSL");
+        }
+    }
+
+    private static void runBrs() {
+        try {
+            Burst.main(args);
+        } catch (Throwable t1) {
+            if (!(t1 instanceof SecurityException)) {
+                LOGGER.error("BurstGUI caught exception starting BRS", t1);
+                showMessage("BurstGUI caught exception starting BRS");
+                onBrsStopped();
+            }
+        }
+    }
+
+    private static void onBrsStopped() {
+        stage.setTitle(stage.getTitle() + " (STOPPED)");
+        trayIcon.setToolTip(trayIcon.getToolTip() + " (STOPPED)");
+    }
+
+    private static void sendJavaOutputToTextArea(TextArea textArea) {
+        System.setOut(new PrintStream(new TextAreaOutputStream(textArea, System.out)));
+        System.setErr(new PrintStream(new TextAreaOutputStream(textArea, System.err)));
+    }
+
+    private static void showMessage(String message) {
+        Platform.runLater(() -> {
+            System.out.println("Showing message: " + message);
+            Dialog dialog = new Alert(Alert.AlertType.ERROR, message, ButtonType.OK);
+            dialog.setGraphic(null);
+            dialog.setHeaderText(null);
+            dialog.setTitle("BRS Message");
+            dialog.show();
+        });
+    }
+
+    private static class TextAreaOutputStream extends OutputStream {
+        private final TextArea textArea;
+        private final PrintStream actualOutput;
+
+        private TextAreaOutputStream(TextArea textArea, PrintStream actualOutput) {
+            this.textArea = textArea;
+            this.actualOutput = actualOutput;
+        }
+
+        @Override
+        public void write(int b) {
+            writeString(new String(new byte[]{(byte)b}));
+        }
+
+        @Override
+        public void write(byte[] b) {
+            writeString(new String(b));
+        }
+
+        private void writeString(String string) {
+            actualOutput.print(string);
+            if (textArea != null) {
+                Platform.runLater(() -> textArea.appendText(string));
+            }
+        }
+    }
+
+    private static class BurstGUISecurityManager extends SecurityManager {
+
+        @Override
+        public void checkExit(int status) {
+            if (!userClosed) {
+                LOGGER.error("BRS Quit unexpectedly! Exit code " + String.valueOf(status));
+                showMessage("BRS Quit unexpectedly! Exit code " + String.valueOf(status));
+                onBrsStopped();
+                throw new SecurityException();
+            }
+        }
+
+        @Override
+        public void checkPermission(Permission perm) {
+        }
+
+        @Override
+        public void checkPermission(Permission perm, Object context) {
+        }
+
+        @Override
+        public void checkCreateClassLoader() {
+        }
+
+        @Override
+        public void checkAccess(Thread t) {
+        }
+
+        @Override
+        public void checkAccess(ThreadGroup g) {
+        }
+
+        @Override
+        public void checkExec(String cmd) {
+        }
+
+        @Override
+        public void checkLink(String lib) {
+        }
+
+        @Override
+        public void checkRead(FileDescriptor fd) {
+        }
+
+        @Override
+        public void checkRead(String file) {
+        }
+
+        @Override
+        public void checkRead(String file, Object context) {
+        }
+
+        @Override
+        public void checkWrite(FileDescriptor fd) {
+        }
+
+        @Override
+        public void checkWrite(String file) {
+        }
+
+        @Override
+        public void checkDelete(String file) {
+        }
+
+        @Override
+        public void checkConnect(String host, int port) {
+        }
+
+        @Override
+        public void checkConnect(String host, int port, Object context) {
+        }
+
+        @Override
+        public void checkListen(int port) {
+        }
+
+        @Override
+        public void checkAccept(String host, int port) {
+        }
+
+        @Override
+        public void checkMulticast(InetAddress maddr) {
+        }
+
+        @Override
+        public void checkPropertiesAccess() {
+        }
+
+        @Override
+        public void checkPropertyAccess(String key) {
+        }
+
+        @Override
+        public void checkPrintJobAccess() {
+        }
+
+        @Override
+        public void checkPackageAccess(String pkg) {
+        }
+
+        @Override
+        public void checkPackageDefinition(String pkg) {
+        }
+
+        @Override
+        public void checkSetFactory() {
+        }
+
+        @Override
+        public void checkSecurityAccess(String target) {
+        }
+    }
+}

--- a/src/brs/BurstGUI.java
+++ b/src/brs/BurstGUI.java
@@ -1,5 +1,7 @@
 package brs;
 
+import brs.props.PropertyService;
+import brs.props.Props;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -127,9 +129,19 @@ public class BurstGUI extends Application {
 
     private static void openWebUi() {
         try {
-            Desktop.getDesktop().browse(new URI("http://localhost:8125"));
-        } catch (Exception e) {
-            showMessage("Error opening web UI. Please open your browser and navigate to \"http://localhost:8125\" or \"https://localhost:8125\" if the node is configured to use SSL");
+            PropertyService propertyService = Burst.getPropertyService();
+            int port = propertyService.getInt(Props.API_PORT);
+            String httpPrefix = propertyService.getBoolean(Props.API_SSL) ? "https://" : "http://";
+            String address = httpPrefix + "localhost:" + String.valueOf(port);
+            try {
+                Desktop.getDesktop().browse(new URI(address));
+            } catch (Exception e) { // Catches parse exception or exception when opening browser
+                LOGGER.error("Could not open browser", e);
+                showMessage("Error opening web UI. Please open your browser and navigate to " + address);
+            }
+        } catch (Exception e) { // Catches error accessing PropertyService
+            LOGGER.error("Could not access PropertyService", e);
+            showMessage("Could not open web UI as could not read BRS configuration.");
         }
     }
 

--- a/src/brs/BurstGUI.java
+++ b/src/brs/BurstGUI.java
@@ -13,7 +13,6 @@ import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.imageio.ImageIO;
 import java.awt.*;
 import java.io.*;
 import java.lang.reflect.Method;
@@ -24,6 +23,8 @@ import java.net.URLClassLoader;
 import java.security.Permission;
 
 public class BurstGUI extends Application {
+    private static final String iconLocation = "/images/burst_overlay_logo.png";
+
     private static String[] args;
     private static boolean userClosed = false;
     private static final Logger LOGGER = LoggerFactory.getLogger(BurstGUI.class);
@@ -45,6 +46,7 @@ public class BurstGUI extends Application {
         textArea.setEditable(false);
         sendJavaOutputToTextArea(textArea);
         primaryStage.setScene(new Scene(textArea, 800, 450));
+        primaryStage.getIcons().add(new javafx.scene.image.Image(getClass().getResourceAsStream(iconLocation)));
         stage = primaryStage;
         showTrayIcon();
         new Thread(BurstGUI::runBrs).start();
@@ -108,7 +110,7 @@ public class BurstGUI extends Application {
             popupMenu.add(showItem);
             popupMenu.add(shutdownItem);
 
-            TrayIcon newTrayIcon = new TrayIcon(ImageIO.read(BurstGUI.class.getResourceAsStream("/images/burst_overlay_logo.png")), "Burst Reference Software", popupMenu);
+            TrayIcon newTrayIcon = new TrayIcon(Toolkit.getDefaultToolkit().createImage(BurstGUI.class.getResource(iconLocation)), "Burst Reference Software", popupMenu);
             newTrayIcon.setImage(newTrayIcon.getImage().getScaledInstance(newTrayIcon.getSize().width, -1, Image.SCALE_SMOOTH));
             newTrayIcon.addActionListener(e -> openWebUi());
             systemTray.add(newTrayIcon);

--- a/src/brs/BurstGUI.java
+++ b/src/brs/BurstGUI.java
@@ -132,7 +132,7 @@ public class BurstGUI extends Application {
     private static void openWebUi() {
         try {
             PropertyService propertyService = Burst.getPropertyService();
-            int port = propertyService.getInt(Props.API_PORT);
+            int port = propertyService.getBoolean(Props.DEV_TESTNET) ? 6876 : propertyService.getInt(Props.API_PORT);
             String httpPrefix = propertyService.getBoolean(Props.API_SSL) ? "https://" : "http://";
             String address = httpPrefix + "localhost:" + String.valueOf(port);
             try {
@@ -150,13 +150,25 @@ public class BurstGUI extends Application {
     private static void runBrs() {
         try {
             Burst.main(args);
-        } catch (Throwable t1) {
-            if (!(t1 instanceof SecurityException)) {
-                LOGGER.error("BurstGUI caught exception starting BRS", t1);
+            try {
+                if (Burst.getPropertyService().getBoolean(Props.DEV_TESTNET)) {
+                    onTestNetEnabled();
+                }
+            } catch (Throwable t) {
+                LOGGER.error("Could not determine if running in testnet mode", t);
+            }
+        } catch (Throwable t) {
+            if (!(t instanceof SecurityException)) {
+                LOGGER.error("BurstGUI caught exception starting BRS", t);
                 showMessage("BurstGUI caught exception starting BRS");
                 onBrsStopped();
             }
         }
+    }
+
+    private static void onTestNetEnabled() {
+        stage.setTitle(stage.getTitle() + " (TESTNET)");
+        trayIcon.setToolTip(trayIcon.getToolTip() + " (TESTNET)");
     }
 
     private static void onBrsStopped() {

--- a/src/brs/BurstLauncher.java
+++ b/src/brs/BurstLauncher.java
@@ -1,0 +1,15 @@
+package brs;
+
+import org.slf4j.LoggerFactory;
+
+public class BurstLauncher {
+    public static void main(String[] args) {
+        try {
+            Class.forName("javafx.application.Application");
+            BurstGUI.main(args);
+        } catch (ClassNotFoundException e) {
+            LoggerFactory.getLogger(BurstLauncher.class).error("Could not start GUI as your JRE does not seem to have JavaFX installed. To install please install the \"openjfx\" package (eg. \"sudo apt install openjfk\")");
+            Burst.main(args);
+        }
+    }
+}

--- a/src/brs/BurstLauncher.java
+++ b/src/brs/BurstLauncher.java
@@ -8,7 +8,7 @@ public class BurstLauncher {
             Class.forName("javafx.application.Application");
             BurstGUI.main(args);
         } catch (ClassNotFoundException e) {
-            LoggerFactory.getLogger(BurstLauncher.class).error("Could not start GUI as your JRE does not seem to have JavaFX installed. To install please install the \"openjfx\" package (eg. \"sudo apt install openjfk\")");
+            LoggerFactory.getLogger(BurstLauncher.class).error("Could not start GUI as your JRE does not seem to have JavaFX installed. To install please install the \"openjfx\" package (eg. \"sudo apt install openjfx\")");
             Burst.main(args);
         }
     }

--- a/src/brs/http/API.java
+++ b/src/brs/http/API.java
@@ -34,7 +34,7 @@ public final class API {
   static Set<Subnet> allowedBotHosts;
   static boolean enableDebugAPI;
   private static final Logger logger = LoggerFactory.getLogger(API.class);
-  private static final int TESTNET_API_PORT = 6876;
+  public static final int TESTNET_API_PORT = 6876;
   private static Server apiServer;
 
   public API(TransactionProcessor transactionProcessor,


### PR DESCRIPTION
Closes #12 

Desktop window for BRS output:

![image](https://user-images.githubusercontent.com/37041552/50739955-ff96de00-11de-11e9-901e-30c5c19c95a9.png)

Tray icon:

![image](https://user-images.githubusercontent.com/37041552/50739965-28b76e80-11df-11e9-8229-3625f3572ac3.png)

The BRS will now launch with GUI by double-clicking `burst.jar`. The GUI launcher detects whether a system tray is present (it isn't on linux) and starts the GUI with the window open if it is not.

It will also not close unless asked to even if BRS crashes, so that the debug output can be read, and also displays an alert to the user when this happens:

![image](https://user-images.githubusercontent.com/37041552/50739984-96fc3100-11df-11e9-8c52-b6649829a1f9.png)

Stdout and stderr are redirected to the GUI but also go to the actual stdout and stderr so the jar can still be used in a command-line environment (or you can specify to use `brs.Burst` as the main class instead.