### PR TITLE
Semver-based versioning system with backwards compatibility

### DIFF
--- a/src/brs/Burst.java
+++ b/src/brs/Burst.java
@@ -44,7 +44,7 @@ import static brs.schema.Tables.UNCONFIRMED_TRANSACTION;
 
 public final class Burst {
 
-  public static final String VERSION     = "2.3.0";
+  public static final Version VERSION = Version.parse("v2.3.0-dev");
   public static final String APPLICATION = "BRS";
 
   private static final String DEFAULT_PROPERTIES_NAME = "brs-default.properties";
@@ -70,7 +70,7 @@ public final class Burst {
   private static PropertyService loadProperties() {
     final Properties defaultProperties = new Properties();
 
-    logger.info("Initializing Burst Reference Software (BRS) version {}", VERSION);
+    logger.info("Initializing Burst Reference Software (BRS) version {}", VERSION.toString());
     try (InputStream is = ClassLoader.getSystemResourceAsStream(DEFAULT_PROPERTIES_NAME)) {
       if (is != null) {
         defaultProperties.load(is);
@@ -128,20 +128,16 @@ public final class Burst {
   }
 
   public static void main(String[] args) {
-    validateVersionNotDev(VERSION);
+    validateVersionNotDev();
     Runtime.getRuntime().addShutdownHook(new Thread(Burst::shutdown));
     init();
   }
 
-  private static void validateVersionNotDev(String version) {
-    if(isDevVersion(version) && System.getProperty("dev") == null) {
+  private static void validateVersionNotDev() {
+    if(VERSION.isPrelease() && System.getProperty("dev") == null) {
       logger.error("THIS IS A DEVELOPMENT WALLET, PLEASE DO NOT USE THIS");
       System.exit(0);
     }
-  }
-
-  private static boolean isDevVersion(String version) {
-    return Integer.parseInt(version.split("\\.")[1]) % 2 != 0;
   }
 
   public static void init(Properties customProperties) {

--- a/src/brs/Burst.java
+++ b/src/brs/Burst.java
@@ -70,7 +70,7 @@ public final class Burst {
   private static PropertyService loadProperties() {
     final Properties defaultProperties = new Properties();
 
-    logger.info("Initializing Burst Reference Software (BRS) version {}", VERSION.toString());
+    logger.info("Initializing Burst Reference Software (BRS) version {}", VERSION);
     try (InputStream is = ClassLoader.getSystemResourceAsStream(DEFAULT_PROPERTIES_NAME)) {
       if (is != null) {
         defaultProperties.load(is);

--- a/src/brs/Constants.java
+++ b/src/brs/Constants.java
@@ -68,7 +68,7 @@ public final class Constants {
   public static final int MAX_AUTOMATED_TRANSACTION_NAME_LENGTH = 30;
   public static final int MAX_AUTOMATED_TRANSACTION_DESCRIPTION_LENGTH = 1000;
 
-  public static final String MIN_VERSION = "2.2.6";
+  public static final Version MIN_VERSION = Version.parse("2.2.6");
 
   static final long UNCONFIRMED_POOL_DEPOSIT_NQT = (Burst.getPropertyService().getBoolean(Props.DEV_TESTNET) ? 50 : 100) * ONE_BURST;
 

--- a/src/brs/Version.java
+++ b/src/brs/Version.java
@@ -3,14 +3,14 @@ package brs;
 import java.util.Objects;
 import java.util.StringTokenizer;
 
-public class Version {
+public final class Version {
     public static final Version EMPTY = new Version(0, 0, 0, PrereleaseTag.NONE, -1);
 
     private final int major;
     private final int minor;
     private final int patch;
-    private final PrereleaseTag prereleaseTag;
-    private final int prereleaseIteration;
+    private final PrereleaseTag prereleaseTag; // NONE if release
+    private final int prereleaseIteration; // -1 if release
 
     public Version(int major, int minor, int patch, PrereleaseTag prereleaseTag, int prereleaseIteration) {
         this.major = major;
@@ -71,18 +71,43 @@ public class Version {
 
     public boolean isGreaterThan(Version otherVersion) {
         if (major > otherVersion.major) return true;
+        if (major < otherVersion.major) return false;
         if (minor > otherVersion.minor) return true;
+        if (minor < otherVersion.minor) return false;
         if (patch > otherVersion.patch) return true;
+        if (patch < otherVersion.patch) return false;
         if (prereleaseTag.priority > otherVersion.prereleaseTag.priority) return true;
+        if (prereleaseTag.priority < otherVersion.prereleaseTag.priority) return false;
         return prereleaseIteration > otherVersion.prereleaseIteration;
     }
 
     public boolean isGreaterThanOrEqualTo(Version otherVersion) {
-        if (major >= otherVersion.major) return true;
-        if (minor >= otherVersion.minor) return true;
-        if (patch >= otherVersion.patch) return true;
-        if (prereleaseTag.priority >= otherVersion.prereleaseTag.priority) return true;
-        return prereleaseIteration >= otherVersion.prereleaseIteration;
+        if (isGreaterThan(otherVersion)) return true;
+        return Objects.equals(this, otherVersion);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Version version = (Version) o;
+
+        if (major != version.major) return false;
+        if (minor != version.minor) return false;
+        if (patch != version.patch) return false;
+        if (prereleaseIteration != version.prereleaseIteration) return false;
+        return prereleaseTag == version.prereleaseTag;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = major;
+        result = 31 * result + minor;
+        result = 31 * result + patch;
+        result = 31 * result + prereleaseTag.hashCode();
+        result = 31 * result + prereleaseIteration;
+        return result;
     }
 
     public enum PrereleaseTag {

--- a/src/brs/Version.java
+++ b/src/brs/Version.java
@@ -21,7 +21,6 @@ public final class Version {
     }
 
     public static Version parse(String version) throws IllegalArgumentException {
-        System.out.println("Parsing " + version);
         try {
             version = version.replace("-", ".").toLowerCase();
             if (version.startsWith("v")) version = version.substring(1);

--- a/src/brs/Version.java
+++ b/src/brs/Version.java
@@ -1,0 +1,113 @@
+package brs;
+
+import java.util.Objects;
+import java.util.StringTokenizer;
+
+public class Version {
+    public static final Version EMPTY = new Version(0, 0, 0, PrereleaseTag.NONE, -1);
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+    private final PrereleaseTag prereleaseTag;
+    private final int prereleaseIteration;
+
+    public Version(int major, int minor, int patch, PrereleaseTag prereleaseTag, int prereleaseIteration) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+        this.prereleaseTag = prereleaseTag;
+        this.prereleaseIteration = prereleaseIteration;
+    }
+
+    public static Version parse(String version) throws IllegalArgumentException {
+        System.out.println("Parsing " + version);
+        try {
+            version = version.replace("-", ".").toLowerCase();
+            if (version.startsWith("v")) version = version.substring(1);
+            StringTokenizer tokenizer = new StringTokenizer(version, ".", false);
+            int major = Integer.parseInt(tokenizer.nextToken());
+            int minor = Integer.parseInt(tokenizer.nextToken());
+            int patch = Integer.parseInt(tokenizer.nextToken());
+            if (tokenizer.hasMoreTokens()) {
+                String[] prereleaseTagAndIteration = tokenizer.nextToken().split("(?<=[a-z])(?=[0-9])");
+                PrereleaseTag prereleaseTag = PrereleaseTag.withTag(prereleaseTagAndIteration[0]);
+                int prereleaseIteration = prereleaseTagAndIteration.length == 2 ? Integer.parseInt(prereleaseTagAndIteration[1]) : -1;
+                return new Version(major, minor, patch, prereleaseTag, prereleaseIteration);
+            } else {
+                return new Version(major, minor, patch, PrereleaseTag.NONE, -1);
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Version not formatted correctly", e);
+        }
+    }
+
+    public boolean backwardsCompatibilityNeeded() { // TODO remove once Constants.MIN_VERSION is greater than 2.3.0
+        return (major < 2 || (major == 2 && minor < 3));
+    }
+
+    public String toBackwardsCompatibleStringIfNeeded(Version peerVersion) { // TODO remove once Constants.MIN_VERSION is greater than 2.3.0
+        // Old peers do not understand new versioning system. It is supported from version major=2,minor=3
+        if (peerVersion.backwardsCompatibilityNeeded()) {
+            return toBackwardsCompatibleString();
+        } else {
+            return toString();
+        }
+    }
+
+    public String toBackwardsCompatibleString() { // TODO remove once Constants.MIN_VERSION is greater than 2.3.0
+        return major + "." + minor + "." + patch;
+    }
+
+    @Override
+    public String toString() {
+        String baseVersion = "v"+major+"."+minor+"."+patch;
+        return prereleaseTag == PrereleaseTag.NONE ? baseVersion : baseVersion+"-"+prereleaseTag.tag+(prereleaseIteration >= 0 ? prereleaseIteration : "");
+    }
+
+    public boolean isPrelease() {
+        return prereleaseTag != PrereleaseTag.NONE;
+    }
+
+    public boolean isGreaterThan(Version otherVersion) {
+        if (major > otherVersion.major) return true;
+        if (minor > otherVersion.minor) return true;
+        if (patch > otherVersion.patch) return true;
+        if (prereleaseTag.priority > otherVersion.prereleaseTag.priority) return true;
+        return prereleaseIteration > otherVersion.prereleaseIteration;
+    }
+
+    public boolean isGreaterThanOrEqualTo(Version otherVersion) {
+        if (major >= otherVersion.major) return true;
+        if (minor >= otherVersion.minor) return true;
+        if (patch >= otherVersion.patch) return true;
+        if (prereleaseTag.priority >= otherVersion.prereleaseTag.priority) return true;
+        return prereleaseIteration >= otherVersion.prereleaseIteration;
+    }
+
+    public enum PrereleaseTag {
+        DEVELOPMENT("dev", 0),
+        ALPHA("alpha", 1),
+        BETA("beta", 2),
+        RC("rc", 3),
+        NONE("", 4),
+        ;
+
+        private final String tag;
+        private final int priority;
+
+        PrereleaseTag(String tag, int priority) {
+            this.tag = tag;
+            this.priority = priority;
+        }
+
+        public static PrereleaseTag withTag(String tag) throws IllegalArgumentException {
+            for(PrereleaseTag prereleaseTag : values()) {
+                if (Objects.equals(prereleaseTag.tag, tag)) {
+                    return prereleaseTag;
+                }
+            }
+            throw new IllegalArgumentException("Provided does not match any prelease tags");
+        }
+    }
+}

--- a/src/brs/Version.java
+++ b/src/brs/Version.java
@@ -61,7 +61,8 @@ public final class Version {
     @Override
     public String toString() {
         String baseVersion = "v"+major+"."+minor+"."+patch;
-        return prereleaseTag == PrereleaseTag.NONE ? baseVersion : baseVersion+"-"+prereleaseTag.tag+(prereleaseIteration >= 0 ? prereleaseIteration : "");
+        String prereleaseSuffix = "-" + prereleaseTag.tag + (prereleaseIteration >= 0 ? prereleaseIteration : "");
+        return prereleaseTag == PrereleaseTag.NONE ? baseVersion : baseVersion + prereleaseSuffix;
     }
 
     public boolean isPrelease() {

--- a/src/brs/http/GetBlockchainStatus.java
+++ b/src/brs/http/GetBlockchainStatus.java
@@ -30,7 +30,7 @@ final class GetBlockchainStatus extends APIServlet.APIRequestHandler {
   JSONStreamAware processRequest(HttpServletRequest req) {
     JSONObject response = new JSONObject();
     response.put("application", Burst.APPLICATION);
-    response.put("version", Burst.VERSION);
+    response.put("version", Burst.VERSION.toString());
     response.put(TIME_RESPONSE, timeService.getEpochTime());
     Block lastBlock = blockchain.getLastBlock();
     response.put("lastBlock", lastBlock.getStringId());

--- a/src/brs/http/GetState.java
+++ b/src/brs/http/GetState.java
@@ -45,7 +45,7 @@ final class GetState extends APIServlet.APIRequestHandler {
     JSONObject response = new JSONObject();
 
     response.put("application", Burst.APPLICATION);
-    response.put("version", Burst.VERSION);
+    response.put("version", Burst.VERSION.toString());
     response.put(TIME_RESPONSE, timeService.getEpochTime());
     response.put("lastBlock", blockchain.getLastBlock().getStringId());
     response.put("cumulativeDifficulty", blockchain.getLastBlock().getCumulativeDifficulty().toString());

--- a/src/brs/http/JSONData.java
+++ b/src/brs/http/JSONData.java
@@ -210,7 +210,7 @@ public final class JSONData {
     json.put("downloadedVolume", peer.getDownloadedVolume());
     json.put("uploadedVolume", peer.getUploadedVolume());
     json.put("application", peer.getApplication());
-    json.put("version", peer.getVersion());
+    json.put("version", peer.getVersion().toString());
     json.put("platform", peer.getPlatform());
     json.put("blacklisted", peer.isBlacklisted());
     json.put("lastUpdated", peer.getLastUpdated());

--- a/src/brs/peer/GetInfo.java
+++ b/src/brs/peer/GetInfo.java
@@ -47,7 +47,7 @@ final class GetInfo extends PeerServlet.PeerRequestHandler {
     //peerImpl.setState(Peer.State.CONNECTED);
     Peers.notifyListeners(peerImpl, Peers.Event.ADDED_ACTIVE_PEER);
 
-    return Peers.myPeerInfoResponse;
+    return peerImpl.getVersion().backwardsCompatibilityNeeded() ? Peers.myPeerInfoResponseBackwardsCompatible : Peers.myPeerInfoResponse;
 
   }
 

--- a/src/brs/peer/Peer.java
+++ b/src/brs/peer/Peer.java
@@ -1,5 +1,6 @@
 package brs.peer;
 
+import brs.Version;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONStreamAware;
 
@@ -15,7 +16,7 @@ public interface Peer extends Comparable<Peer> {
 
   State getState();
 
-  String getVersion();
+  Version getVersion();
 
   String getApplication();
 
@@ -33,7 +34,7 @@ public interface Peer extends Comparable<Peer> {
 
   boolean isAtLeastMyVersion();
 
-  boolean isHigherOrEqualVersionThan(String version);
+  boolean isHigherOrEqualVersionThan(Version version);
 
   void blacklist(Exception cause, String description);
 

--- a/src/brs/peer/PeerImpl.java
+++ b/src/brs/peer/PeerImpl.java
@@ -126,7 +126,7 @@ final class PeerImpl implements Peer {
       return false;
     }
 
-    return ourVersion.isGreaterThanOrEqualTo(possiblyLowerVersion);
+    return possiblyLowerVersion.isGreaterThanOrEqualTo(ourVersion);
   }
 
   public boolean isAtLeastMyVersion() {

--- a/src/brs/peer/PeerImpl.java
+++ b/src/brs/peer/PeerImpl.java
@@ -1,9 +1,6 @@
 package brs.peer;
 
-import brs.BlockchainProcessor;
-import brs.Burst;
-import brs.BurstException;
-import brs.Constants;
+import brs.*;
 import brs.crypto.Crypto;
 import brs.props.Props;
 import brs.util.Convert;
@@ -20,8 +17,6 @@ import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 final class PeerImpl implements Peer {
@@ -34,7 +29,7 @@ final class PeerImpl implements Peer {
   private volatile boolean shareAddress;
   private volatile String platform;
   private volatile String application;
-  private volatile String version;
+  private volatile Version version;
   private volatile boolean isOldVersion;
   private volatile long blacklistingTime;
   private volatile State state;
@@ -51,7 +46,7 @@ final class PeerImpl implements Peer {
       this.port = new URL("http://" + announcedAddress).getPort();
     } catch (MalformedURLException ignore) {}
     this.state = State.NON_CONNECTED;
-    this.version = ""; //not null
+    this.version = Version.EMPTY; //not null
     this.shareAddress = true;
   }
 
@@ -117,63 +112,35 @@ final class PeerImpl implements Peer {
   }
 
   @Override
-  public String getVersion() {
+  public Version getVersion() {
     return version;
   }
 
   // semantic versioning for peer versions. here: ">=" negate it for "<"
-  public boolean isHigherOrEqualVersionThan(String ourVersion) {
+  public boolean isHigherOrEqualVersionThan(Version ourVersion) {
     return isHigherOrEqualVersion(ourVersion, version);
   }
 
-  public static boolean isHigherOrEqualVersion(String ourVersion, String possiblyLowerVersion) {
-    if(possiblyLowerVersion == null || possiblyLowerVersion.isEmpty()) {
+  public static boolean isHigherOrEqualVersion(Version ourVersion, Version possiblyLowerVersion) {
+    if (ourVersion == null || possiblyLowerVersion == null) {
       return false;
     }
 
-    Pattern pattern = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)?");
-    Matcher matchPeer = pattern.matcher(possiblyLowerVersion);
-    Matcher matchCompare = pattern.matcher(ourVersion);
-
-    if (matchPeer.find() && matchCompare.find()) {  // if both peer version and our comparison version are sane
-      // we have simplified versions with 3 limbs: X.Y.Z
-      for (int limb = 1; limb <= 3; limb++) {
-        int peerLimb = Integer.parseInt(matchPeer.group(limb));
-        int comparisonLimb = Integer.parseInt(matchCompare.group(limb));
-        if (peerLimb > comparisonLimb) {
-          return true;
-        }
-        if (peerLimb < comparisonLimb) {
-          return false;
-        }
-      }
-      return true; // all limbs equal
-    }
-    return false; // either version not sane
+    return ourVersion.isGreaterThanOrEqualTo(possiblyLowerVersion);
   }
 
   public boolean isAtLeastMyVersion() {
-    return isHigherOrEqualVersionThan(Burst.VERSION.substring(0, Burst.VERSION.lastIndexOf(".")) + ".0");
+    return isHigherOrEqualVersionThan(Burst.VERSION);
   }
   
   void setVersion(String version) {
-    this.version = version;
+    this.version = Version.EMPTY;
     isOldVersion = false;
     if (Burst.APPLICATION.equals(application) && version != null) {
-      // a runtime exception should be ok, if someone broke the constants
-      int[] currentVersionParts = Arrays.stream(Constants.MIN_VERSION.split("\\.")).mapToInt(Integer::parseInt).toArray();
-
       try {
-        int[] versionParts = Arrays.stream(version.split("\\.")).mapToInt(Integer::parseInt).toArray();
-
-        for (int i = 0; i < currentVersionParts.length; i++) {
-          if ( versionParts[i] != currentVersionParts[i] ) {
-            isOldVersion = versionParts[i] < currentVersionParts[i];
-            break;
-          }
-        }
-      }
-      catch (NumberFormatException e) {
+        this.version = Version.parse(version);
+        isOldVersion = Constants.MIN_VERSION.isGreaterThan(this.version);
+      } catch (IllegalArgumentException e) {
         isOldVersion = true;
       }
     }
@@ -200,7 +167,7 @@ final class PeerImpl implements Peer {
   @Override
   public String getSoftware() {
     return Convert.truncate(application, "?", 10, false)
-        + " (" + Convert.truncate(version, "?", 10, false) + ")"
+        + " (" + Convert.truncate(version.toString(), "?", 10, false) + ")"
         + " @ " + Convert.truncate(platform, "?", 10, false);
   }
 
@@ -356,7 +323,7 @@ final class PeerImpl implements Peer {
       connection.setDoOutput(true);
       connection.setConnectTimeout(Peers.connectTimeout);
       connection.setReadTimeout(Peers.readTimeout);
-      connection.addRequestProperty("User-Agent","BRS/" + Burst.VERSION);
+      connection.addRequestProperty("User-Agent", "BRS/" + Burst.VERSION.toBackwardsCompatibleStringIfNeeded(this.version));
       connection.setRequestProperty("Accept-Encoding", "gzip");
       connection.setRequestProperty("Connection", "close");
 
@@ -442,7 +409,7 @@ final class PeerImpl implements Peer {
   }
 
   void connect(int currentTime) {
-    JSONObject response = send(Peers.myPeerInfoRequest);
+    JSONObject response = send(version.backwardsCompatibilityNeeded() ? Peers.myPeerInfoRequestBackwardsCompatible : Peers.myPeerInfoRequest);
     if (response != null) {
       application = (String)response.get("application");
       setVersion((String) response.get("version"));

--- a/test/java/brs/entity/VersionTest.java
+++ b/test/java/brs/entity/VersionTest.java
@@ -58,4 +58,15 @@ public class VersionTest {
         assertFalse(higher.isPrelease());
         assertTrue(higherPreRelease.isPrelease());
     }
+
+    @Test
+    public void testBackwardsCompatibility() {
+        Version version = Version.parse("v2.3.0");
+        assertTrue(Version.EMPTY.backwardsCompatibilityNeeded());
+        assertTrue(Version.parse("v2.2.7").backwardsCompatibilityNeeded());
+        assertFalse(Version.parse("v2.3.0").backwardsCompatibilityNeeded());
+        assertEquals("2.3.0", version.toBackwardsCompatibleString());
+        assertEquals("2.3.0", version.toBackwardsCompatibleStringIfNeeded(Version.parse("v2.2.7")));
+        assertEquals("v2.3.0", version.toBackwardsCompatibleStringIfNeeded(Version.parse("v2.3.0")));
+    }
 }

--- a/test/java/brs/entity/VersionTest.java
+++ b/test/java/brs/entity/VersionTest.java
@@ -1,0 +1,61 @@
+package brs.entity;
+
+import brs.Version;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VersionTest {
+    @Test
+    public void testVersionParse() {
+        String[] validVersions = {
+                "2.2.2",
+                "v1.2.3",
+                "v0.2.7-dev",
+                "1.24.2-rc9",
+                "v0.8.999-beta99"
+        };
+
+        String[] invalidVersions = {
+                "v2.0",
+                "v1.2.3-abc123",
+                "v1a.2.3-dev",
+                "1.0-dev",
+                "v1.2.3-123dev123",
+        };
+
+        for (String versionString : validVersions) {
+            Version version = Version.parse(versionString);
+            if (versionString.startsWith("v")) {
+                assertEquals(versionString, version.toString());
+            } else {
+                assertEquals("v" + versionString, version.toString());
+            }
+        }
+
+        for (String versionString : invalidVersions) {
+            try {
+                Version version = Version.parse(versionString);
+                throw new RuntimeException("Did not fail to parse: " + versionString);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void testVersionCompare() {
+        Version lower = Version.parse("v1.0.0");
+        Version equal = Version.parse("v1.0.0");
+        Version higher = Version.parse("v1.0.1");
+        Version higherPreRelease = Version.parse("v1.5.0-dev");
+
+        assertFalse(lower.isGreaterThan(equal));
+        assertTrue(lower.isGreaterThanOrEqualTo(equal));
+        assertFalse(lower.isGreaterThanOrEqualTo(higher));
+        assertTrue(higher.isGreaterThan(lower));
+        assertFalse(higher.isGreaterThanOrEqualTo(higherPreRelease));
+        assertTrue(higherPreRelease.isGreaterThan(higher));
+        assertFalse(higher.isPrelease());
+        assertTrue(higherPreRelease.isPrelease());
+    }
+}


### PR DESCRIPTION
The Version class contains a parser which can both parse old versions from old nodes and new nodes (with this patch)

If the P2P networking detects it is talking to a node older than 2.3, it does not send them the new format, just the old one. The parser does not care if it gets the new version or the old version.