### PR TITLE
UI: Sign Arbitrary Message

### DIFF
--- a/html/ui/html/header.html
+++ b/html/ui/html/header.html
@@ -38,6 +38,7 @@
             <li><a href="#" data-toggle="modal" data-target="#token_modal" data-i18n="generate_token">Generate Token</a></li>
             <li><a href="#" data-toggle="modal" data-target="#transaction_operations_modal" data-i18n="transaction_operations">Transaction Operations</a></li>
             <li><a href="#" data-toggle="modal" data-target="#reward_assignment_modal" data-i18n="reward_assignment">Reward Assignment</a></li>
+            <li><a href="#" data-toggle="modal" data-target="#sign_message_modal" data-i18n="sign_arbitrary_message">Sign arbitrary message</a></li>
           </ul>
         </li>
         <li class="dropdown">

--- a/html/ui/html/modals/sign_message.html
+++ b/html/ui/html/modals/sign_message.html
@@ -1,0 +1,57 @@
+<div class="modal fade modal-no-hide" id="sign_message_modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">Arbitrary Message Signature / Verification</h4>
+      </div>
+      <div class="modal-body">
+        <ul class="nav nav-pills nav-justified" style="margin-bottom:10px">
+          <li class="active" id="sign_message_nav" data-tab="sign_message"><a href="#">Sign Message</a></li>
+          <li data-tab="verify_message"><a href="#">Verify Message Signature</a></li>
+        </ul>
+        <div id="sign_message_modal_sign_message" class="sign_message_modal_content" style="display:none">
+          <form role="form" id="sign_message_form" class="sign_message_form" autocomplete="off">
+            <div class="callout callout-danger error_message" id="sign_message_error" style="display:none"></div>
+            <div class="callout callout-warning"><b>WARNING: Before signing an arbitrary message, think. Someone may be actually asking you to sign a transaction, which would let them spend your funds (A transaction looks like a long hex-encoded string). Think before blindly signing a message that someone has asked you to sign.</b></div>
+            <div class="callout callout-info" id="sign_message_output" style="display:none;word-wrap:break-word;"></div>
+            <div class="form-group">
+              <label for="sign_message_data">Message</label>
+              <textarea class="form-control" name="message" id="sign_message_data" placeholder="Message" tabindex="1" rows="10"></textarea>
+              <label for="sign_message_data_is_hex">Hex Encoded</label>
+              <input type="checkbox" name="messageIsHex" id="sign_message_data_is_hex" />
+            </div>
+            <div class="form-group">
+              <label for="sign_message_passphrase" data-i18n="passphrase">Passphrase</label>
+              <input type="password" name="secretPhrase" id="sign_message_passphrase" class="form-control" placeholder="" tabindex="5" autocomplete="">
+            </div>
+          </form>
+        </div>
+        <div id="sign_message_modal_verify_message" class="sign_message_modal_content" style="display:none">
+          <form role="form" id="verify_message_form" class="verify_message_form" autocomplete="off">
+            <div class="callout callout-danger error_message" id="verify_message_error" style="display:none"></div>
+            <div class="callout callout-info" id="verify_message_output" style="display:none;"></div>
+            <div class="form-group">
+              <label for="verify_message_data">Message</label>
+              <textarea class="form-control" name="website" id="verify_message_data" placeholder="Message" tabindex="1" rows="10"></textarea>
+              <label for="verify_message_data_is_hex">Hex Encoded</label>
+              <input type="checkbox" name="messageIsHex" id="verify_message_data_is_hex" />
+            </div>
+            <div class="form-group">
+              <label for="verify_message_public_key">Signer's Public Key</label>
+              <input type="text" class="form-control" name="publicKey" id="verify_message_public_key" placeholder="Public Key(Hex encoded)" tabindex="2" value="" />
+            </div>
+            <div class="form-group">
+              <label for="verify_message_signature">Signature</label>
+              <input type="text" class="form-control" name="signature" id="verify_message_signature" placeholder="Signature (Hex encoded)" tabindex="2" value="" />
+            </div>
+          </form>
+        </div>
+      </div>
+      <div class="modal-footer" style="margin-top:0;">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="sign_message_modal_button">Sign</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/html/ui/index.html
+++ b/html/ui/index.html
@@ -126,6 +126,7 @@
       BRS.loadModalHTML("html/modals/transaction_info.html");
       BRS.loadModalHTML("html/modals/transaction_operations.html");
       BRS.loadModalHTML("html/modals/user_info.html");
+      BRS.loadModalHTML("html/modals/sign_message.html");
     </script>
 
     <script src="js/brs.js" type="text/javascript"></script>
@@ -156,6 +157,7 @@
     <script src="js/brs.modals.accountinfo.js" type="text/javascript"></script>
     <script src="js/brs.modals.advanced.js" type="text/javascript"></script>
     <script src="js/brs.modals.request.js" type="text/javascript"></script>
+    <script src="js/brs.modals.signmessage.js" type="text/javascript"></script>
     <script src="js/brs.console.js" type="text/javascript"></script>
     <script src="js/brs.util.js" type="text/javascript"></script>
     <script src="js/brs.escrow.js" type="text/javascript"></script>

--- a/html/ui/js/brs.forms.js
+++ b/html/ui/js/brs.forms.js
@@ -19,7 +19,9 @@ var BRS = (function(BRS, $, undefined) {
 
     $(".modal button.btn-primary:not([data-dismiss=modal]):not([data-ignore=true])").click(function() {
         // ugly hack - this whole ui is hack, got a big urge to vomit
-        if (!$(this).hasClass("multi-out")) {
+        if ($(this)[0].id === "sign_message_modal_button") { // hack hackity hack!
+            BRS.forms.signModalButtonClicked();
+        } else if (!$(this).hasClass("multi-out")) {
             BRS.submitForm($(this).closest(".modal"), $(this));
         }
     });

--- a/html/ui/js/brs.modals.signmessage.js
+++ b/html/ui/js/brs.modals.signmessage.js
@@ -30,7 +30,7 @@ var BRS = (function(BRS, $, undefined) {
                 $("#sign_message_error").show();
             }
             signature = BRS.signBytes(data, passphrase);
-            $("#sign_message_output").text("Signature is " + signature);
+            $("#sign_message_output").text("Signature is " + signature + ". Your public key is " + BRS.getPublicKey(passphrase));
             $("#sign_message_output").show();
         }, false);
     };

--- a/html/ui/js/brs.modals.signmessage.js
+++ b/html/ui/js/brs.modals.signmessage.js
@@ -1,0 +1,87 @@
+/**
+ * @depends {brs.js}
+ * @depends {brs.modals.js}
+ */
+var BRS = (function(BRS, $, undefined) {
+    $("#sign_message_modal").on("show.bs.modal", function(e) {
+        $("#sign_message_output, #verify_message_output").html("").hide();
+
+        $("#sign_message_modal_sign_message").show();
+        $("#sign_message_modal_button").text("Sign Message").data("form", "sign_message_form");
+    });
+
+    BRS.forms.signModalButtonClicked = function() {
+		if ($("#sign_message_nav").hasClass("active")) {
+			BRS.forms.signMessage();
+		} else {
+		    BRS.forms.verifyMessage();
+		}
+    };
+
+    BRS.forms.signMessage = function() {
+        var isHex = $("#sign_message_data_is_hex").is(":checked");
+        var data = $("#sign_message_data").val();
+        var passphrase = converters.stringToHexString($("#sign_message_passphrase").val());
+        if (!isHex) data = converters.stringToHexString(data);
+        BRS.sendRequest("parseTransaction", { "transactionBytes": data }, function(result) {
+            console.log(result);
+            if (result.errorCode == null) {
+                $("#sign_message_error").text("WARNING: YOU ARE SIGNING A TRANSACTION. IF YOU WERE NOT TRYING TO SIGN A TRANSACTION MANUALLY, DO NOT GIVE THIS SIGNATURE OUT AS IF YOU WERE ASKED TO SIGN THIS MESSAGE. IT COULD ALLOW OTHERS TO SPEND YOUR FUNDS.");
+                $("#sign_message_error").show();
+            }
+            signature = BRS.signBytes(data, passphrase);
+            $("#sign_message_output").text("Signature is " + signature);
+            $("#sign_message_output").show();
+        }, false);
+    };
+
+    BRS.forms.verifyMessage = function() {
+        var isHex = $("#verify_message_data_is_hex").is(":checked");
+        var data = $("#verify_message_data").val();
+        var signature = $.trim($("#verify_message_signature").val());
+        var publicKey = $.trim($("#verify_message_public_key").val());
+        if (!isHex) data = converters.stringToHexString(data);
+        var result = BRS.verifyBytes(signature, data, publicKey);
+        if (result) {
+            $("#verify_message_error").hide();
+            $("#verify_message_output").text("Signature is valid");
+            $("#verify_message_output").show();
+        } else {
+            $("#verify_message_output").hide();
+            $("#verify_message_error").text("Signature is invalid");
+            $("#verify_message_error").show();
+        }
+    };
+
+    $("#sign_message_modal ul.nav li").click(function(e) {
+        e.preventDefault();
+
+        var tab = $(this).data("tab");
+
+        $(this).siblings().removeClass("active");
+        $(this).addClass("active");
+
+        $(".sign_message_modal_content").hide();
+
+        var content = $("#sign_message_modal_" + tab);
+
+        if (tab === "sign_message") {
+            $("#sign_message_modal_button").text("Sign Message").data("form", "sign_message_form");
+        }
+        else {
+            $("#sign_message_modal_button").text("Verify Message").data("form", "verify_message_form");
+        }
+
+        $("#sign_message_modal .error_message").hide();
+
+        content.show();
+    });
+
+    $("#sign_message_modal").on("hidden.bs.modal", function(e) {
+        $(this).find(".sign_message_modal_content").hide();
+        $(this).find("ul.nav li.active").removeClass("active");
+        $("#sign_message_nav").addClass("active");
+    });
+
+    return BRS;
+}(BRS || {}, jQuery));

--- a/html/ui/js/brs.modals.signmessage.js
+++ b/html/ui/js/brs.modals.signmessage.js
@@ -26,7 +26,7 @@ var BRS = (function(BRS, $, undefined) {
         BRS.sendRequest("parseTransaction", { "transactionBytes": data }, function(result) {
             console.log(result);
             if (result.errorCode == null) {
-                $("#sign_message_error").text("WARNING: YOU ARE SIGNING A TRANSACTION. IF YOU WERE NOT TRYING TO SIGN A TRANSACTION MANUALLY, DO NOT GIVE THIS SIGNATURE OUT AS IF YOU WERE ASKED TO SIGN THIS MESSAGE. IT COULD ALLOW OTHERS TO SPEND YOUR FUNDS.");
+                $("#sign_message_error").text("WARNING: YOU ARE SIGNING A TRANSACTION. IF YOU WERE NOT TRYING TO SIGN A TRANSACTION MANUALLY, DO NOT GIVE THIS SIGNATURE OUT. IT COULD ALLOW OTHERS TO SPEND YOUR FUNDS.");
                 $("#sign_message_error").show();
             }
             signature = BRS.signBytes(data, passphrase);


### PR DESCRIPTION
This allows a user to sign any message using their private key. It also checks if the message was a valid transaction to prevent people from asking naive users to sign a transaction and stealing funds.

This is going to be used in the new pool software to let users set their minimum payouts.

![image](https://user-images.githubusercontent.com/37041552/54089072-ce609880-435c-11e9-84ee-7189b2811c6d.png)

![image](https://user-images.githubusercontent.com/37041552/54089076-e0dad200-435c-11e9-9739-f546d6d5fc11.png)

![image](https://user-images.githubusercontent.com/37041552/54089081-f51ecf00-435c-11e9-9e92-fefcb17369c7.png)

![image](https://user-images.githubusercontent.com/37041552/54089083-036ceb00-435d-11e9-810d-230dabae9ce9.png)

![image](https://user-images.githubusercontent.com/37041552/54089091-154e8e00-435d-11e9-969d-83a084e1b15e.png)
