### PR TITLE
Manual CORS headers instead of through Jetty

### DIFF
--- a/conf/brs-default.properties
+++ b/conf/brs-default.properties
@@ -185,9 +185,6 @@ API.ServerIdleTimeout = 30000
 # the http/json API.
 API.UI_Dir = html/ui
 
-# Enable Cross Origin Filter for the API server.
-API.CrossOriginFilter = off
-
 # Enable SSL for the API server (also need to set API.SSL_keyStorePath and API.SSL_keyStorePassword).
 API.SSL = off
 
@@ -317,3 +314,6 @@ brs.ShutdownTimeout = 180
 # Enable the indirect incoming tracker service. This allows you to see transactions where you are paid
 # but are not the direct recipient eg. Multi-Outs.
 IndirectIncomingService.Enable = true
+
+# List of CORS allowed origins.
+API.AllowedOrigins=*

--- a/src/brs/http/API.java
+++ b/src/brs/http/API.java
@@ -17,7 +17,6 @@ import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.eclipse.jetty.servlets.DoSFilter;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.slf4j.Logger;
@@ -146,12 +145,6 @@ public final class API {
       }
 
       apiHandler.addServlet(APITestServlet.class, "/test");
-
-      if (propertyService.getBoolean(Props.API_CROSS_ORIGIN_FILTER)) {
-        FilterHolder filterHolder = apiHandler.addFilter(CrossOriginFilter.class, "/*", null);
-        filterHolder.setInitParameter("allowedHeaders", "*");
-        filterHolder.setAsyncSupported(true);
-      }
 
       if (propertyService.getBoolean(Props.JETTY_API_GZIP_FILTER)) {
         GzipHandler gzipHandler = new GzipHandler();

--- a/src/brs/http/APIServlet.java
+++ b/src/brs/http/APIServlet.java
@@ -37,6 +37,7 @@ public final class APIServlet extends HttpServlet {
 
     enforcePost = propertyService.getBoolean(Props.API_SERVER_ENFORCE_POST);
     acceptSurplusParams = propertyService.getBoolean(Props.API_ACCEPT_SURPLUS_PARAMS);
+    allowedOrigins = propertyService.getString(Props.API_ALLOWED_ORIGINS);
     
     final Map<String, APIRequestHandler> map = new HashMap<>();
     final Map<String, PrimitiveRequestHandler> primitiveMap = new HashMap<>();
@@ -220,6 +221,7 @@ public final class APIServlet extends HttpServlet {
   }
 
   private static boolean enforcePost;
+  private static String allowedOrigins;
 
   public static Map<String, APIRequestHandler> apiRequestHandlers;
   private static Map<String, PrimitiveRequestHandler> primitiveRequestHandlers;
@@ -245,7 +247,8 @@ public final class APIServlet extends HttpServlet {
   }
 
   private void process(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-
+    resp.setHeader("Access-Control-Allow-Methods", "GET, POST");
+    resp.setHeader("Access-Control-Allow-Origin", allowedOrigins);
     resp.setHeader("Cache-Control", "no-cache, no-store, must-revalidate, private");
     resp.setHeader("Pragma", "no-cache");
     resp.setDateHeader("Expires", 0);

--- a/src/brs/props/Props.java
+++ b/src/brs/props/Props.java
@@ -122,11 +122,11 @@ public class Props {
   public static final Prop<Integer> API_V2_PORT    = new Prop<>("API.V2.Port", 8121);
 
   public static final Prop<String> API_UI_DIR  = new Prop<>("API.UI_Dir", "html/ui");
-  public static final Prop<Boolean> API_CROSS_ORIGIN_FILTER = new Prop<>("API.CrossOriginFilter", false);
   public static final Prop<String> API_SSL_KEY_STORE_PATH     = new Prop<>("API.SSL_keyStorePath", "keystore");
   public static final Prop<String> API_SSL_KEY_STORE_PASSWORD = new Prop<>("API.SSL_keyStorePassword", "password");
   public static final Prop<Integer> API_SERVER_IDLE_TIMEOUT = new Prop<>("API.ServerIdleTimeout", 30000);
   public static final Prop<Boolean> API_SERVER_ENFORCE_POST = new Prop<>("API.ServerEnforcePOST", true);
+  public static final Prop<String> API_ALLOWED_ORIGINS = new Prop<>("API.AllowedOrigins", "*");
 
   public static final Prop<Boolean> JETTY_API_GZIP_FILTER = new Prop<>("JETTY.API.GzipFilter", true);
   public static final Prop<String> JETTY_API_GZIP_FILTER_METHODS = new Prop<>("JETTY.API.GZIPFilter.methods", "GET, POST");


### PR DESCRIPTION
This ensures cors headers are where they should be - on the `/burst` endpoint **only**.

Closes #71 