### PR TITLE
Auto Pop-Off

### DIFF
--- a/conf/brs-default.properties
+++ b/conf/brs-default.properties
@@ -315,5 +315,11 @@ brs.ShutdownTimeout = 180
 # but are not the direct recipient eg. Multi-Outs.
 IndirectIncomingService.Enable = true
 
+# Auto Pop Off means that BRS will, when failing to push a block received whilst syncing (from another
+# peer), pop off n-1 blocks, where n is the number of failures to push a block at this height.
+# This, combined with blacklisting, should significantly lower the chance of your wallet becoming stuck,
+# whilst syncing or when operating normally.
+AutoPopOff.Enable = true
+
 # List of CORS allowed origins.
 API.AllowedOrigins=*

--- a/src/brs/props/Props.java
+++ b/src/brs/props/Props.java
@@ -168,6 +168,8 @@ public class Props {
 
   public static final Prop<Boolean> INDIRECT_INCOMING_SERVICE_ENABLE = new Prop<>("IndirectIncomingService.Enable", true);
 
+  public static final Prop<Boolean> AUTO_POP_OFF_ENABLED = new Prop<>("AutoPopOff.Enable", true);
+
   private Props() { //no need to construct
   }
 }


### PR DESCRIPTION
Closes #130 

When failing to push an imported block (from another node), after clearing cache and blacklisting offending node, pops off `n-1` blocks, where `n` is the number of failures to push a block at this height.

Example: Block cannot be pushed at height 500. Initially 0 blocks will be popped, and we try again. Failed again? Pop 1 block, try again. Failed again? Pop 2 blocks, try again, etc.

If once we have popped 10 blocks we encounter a failure at height 490, we start over. Pop no blocks, try again. Failed again? Pop 1 block, try to sync again.