### PR TITLE
Single dockerfile args configuration

### DIFF
--- a/Dockerfile.mainnet
+++ b/Dockerfile.mainnet
@@ -4,12 +4,12 @@ COPY . .
 RUN ./gradlew -Dheadless=true -DskipDeleteTempPackageFiles=true buildPackage
 
 FROM openjdk:13-slim
-ARG CUSTOM_CONF=.sqlite
+ARG CUSTOM_CONF=brs.properties.sqlite
 WORKDIR /app
 COPY --from=build /app/dist/tmp/burst.jar .
 COPY --from=build /app/html html
 VOLUME ["/conf", "/db"]
-COPY conf/brs.properties$CUSTOM_CONF /conf/brs.properties
+COPY conf/$CUSTOM_CONF /conf/brs.properties
 COPY conf/brs-default.properties /conf/brs-default.properties
 COPY conf/logging-docker.properties /conf/logging.properties
 COPY conf/logging-default.properties /conf/logging-default.properties

--- a/Dockerfile.mainnet
+++ b/Dockerfile.mainnet
@@ -4,12 +4,14 @@ COPY . .
 RUN ./gradlew -Dheadless=true -DskipDeleteTempPackageFiles=true buildPackage
 
 FROM openjdk:13-slim
+ARG CUSTOM_CONF=.sqlite
 WORKDIR /app
 COPY --from=build /app/dist/tmp/burst.jar .
 COPY --from=build /app/html html
 VOLUME ["/conf", "/db"]
-COPY conf/brs.properties.h2 /conf/brs.properties
+COPY conf/brs.properties$CUSTOM_CONF /conf/brs.properties
 COPY conf/brs-default.properties /conf/brs-default.properties
+COPY conf/logging-docker.properties /conf/logging.properties
 COPY conf/logging-default.properties /conf/logging-default.properties
 EXPOSE 8125 8123 8121
 ENTRYPOINT ["java", "-jar", "burst.jar", "--config", "/conf"]

--- a/Dockerfile.testnet
+++ b/Dockerfile.testnet
@@ -4,12 +4,14 @@ COPY . .
 RUN ./gradlew -Dheadless=true -DskipDeleteTempPackageFiles=true buildPackage
 
 FROM openjdk:13-slim
+ARG CUSTOM_CONF=.sqlite
 WORKDIR /app
 COPY --from=build /app/dist/tmp/burst.jar .
 COPY --from=build /app/html html
-VOLUME ["/conf"]
-COPY conf/brs.properties.mariadb /conf/brs.properties
-COPY conf/brs-default.properties /conf/brs-default.properties
+VOLUME ["/conf", "/db"]
+COPY conf/brs.properties$CUSTOM_CONF /conf/brs.properties
+COPY conf/brs-default-testnet.properties /conf/brs-default.properties
+COPY conf/logging-docker.properties /conf/logging.properties
 COPY conf/logging-default.properties /conf/logging-default.properties
-EXPOSE 8125 8123 8121
+EXPOSE 7123 6878 6876
 ENTRYPOINT ["java", "-jar", "burst.jar", "--config", "/conf"]

--- a/Dockerfile.testnet
+++ b/Dockerfile.testnet
@@ -4,12 +4,12 @@ COPY . .
 RUN ./gradlew -Dheadless=true -DskipDeleteTempPackageFiles=true buildPackage
 
 FROM openjdk:13-slim
-ARG CUSTOM_CONF=.sqlite
+ARG CUSTOM_CONF=brs.properties.sqlite
 WORKDIR /app
 COPY --from=build /app/dist/tmp/burst.jar .
 COPY --from=build /app/html html
 VOLUME ["/conf", "/db"]
-COPY conf/brs.properties$CUSTOM_CONF /conf/brs.properties
+COPY conf/$CUSTOM_CONF /conf/brs.properties
 COPY conf/brs-default-testnet.properties /conf/brs-default.properties
 COPY conf/logging-docker.properties /conf/logging.properties
 COPY conf/logging-default.properties /conf/logging-default.properties

--- a/conf/brs-default-testnet.properties
+++ b/conf/brs-default-testnet.properties
@@ -252,7 +252,7 @@ DEV.Offline = no
 # Use testnet, leave set to false unless you are really testing.
 # Never unlock your real accounts on testnet! Use separate accounts for testing only.
 # When using testnet, P2P port is hardcoded as 7123.
-DEV.TestNet = no
+DEV.TestNet = yes
 DEV.API.Port = 6876
 DEV.API.V2.Port = 6878
 
@@ -265,10 +265,10 @@ DEV.DB.Password =
 DEV.TimeWarp = 1
 
 # Peers used for testnet only.
-DEV.P2P.BootstrapPeers =
+DEV.P2P.BootstrapPeers = 144.217.93.166; testnet.getburst.net; octalsburstnode.ddns.net; 3.16.150.48; 75.100.126.230; testddns.gotdns.com; aya.onthewifi.com; 212.37.175.94; burst-node-test.duckdns.org; test-burst.megash.it; happyfarmer.internet-box.ch;
 
 # Testnet only. These peers will always be sent rebroadcast transactions. They are also automatically added to DEV.P2P.BootstrapPeers, so no need for duplicates.
-DEV.P2P.rebroadcastTo =
+DEV.P2P.rebroadcastTo = 144.217.93.166; testnet.getburst.net; octalsburstnode.ddns.net; 3.16.150.48; 75.100.126.230; testddns.gotdns.com; aya.onthewifi.com; 212.37.175.94; burst-node-test.duckdns.org; test-burst.megash.it; happyfarmer.internet-box.ch;
 
 # Force all deadlines submitted to actually be a certain deadline.
 # This will mess up syncing with other wallets, so please only use in offline mode.
@@ -281,6 +281,15 @@ DEV.dumpPeersVersion =
 # Force re-build of derived objects tables at start.
 DEV.forceScan = off
 
+# Testnet Blockchain Historical Moments
+DEV.digitalGoodsStore.startBlock = 0
+DEV.automatedTransactions.startBlock = 0
+DEV.atFixBlock2.startBlock = 0
+DEV.atFixBlock3.startBlock = 0
+DEV.atFixBlock4.startBlock = 0
+DEV.preDymaxion.startBlock = 0
+DEV.poc2.startBlock = 0
+DEV.rewardRecipient.startBlock = 6500
 
 # Debugging (part of Development - isn't it)
 

--- a/conf/brs.properties.h2
+++ b/conf/brs.properties.h2
@@ -1,10 +1,9 @@
-#### API SERVER ####
-API.Listen = 0.0.0.0
-API.allowed = *
-
-#### DATABASE ####
-
-# Database connection JDBC url
-DB.Url=jdbc:h2:file:/db/burst;DB_CLOSE_ON_EXIT=FALSE
+# mainnet
+DB.Url=jdbc:h2:file:/db/burst.h2;DB_CLOSE_ON_EXIT=FALSE
 DB.Username=
 DB.Password=
+
+# testnet
+DEV.DB.Url=jdbc:h2:file:/db/burst.h2;DB_CLOSE_ON_EXIT=FALSE
+DEV.DB.Username=
+DEV.DB.Password=

--- a/conf/brs.properties.mariadb
+++ b/conf/brs.properties.mariadb
@@ -1,10 +1,9 @@
-#### API SERVER ####
-API.Listen = 0.0.0.0
-API.allowed = *
-
-#### DATABASE ####
-
-# Database connection JDBC url
+# mainnet
 DB.Url=jdbc:mariadb://mariadb:3306/burst
 DB.Username=root
 DB.Password=burst
+
+# testnet
+DEV.DB.Url=jdbc:mariadb://mariadb:3306/burst
+DEV.DB.Username=root
+DEV.DB.Password=burst

--- a/conf/brs.properties.sqlite
+++ b/conf/brs.properties.sqlite
@@ -1,0 +1,9 @@
+# mainnet
+DB.Url=jdbc:sqlite:/db/burst.sqlite
+DB.Username=
+DB.Password=
+
+# testnet
+DEV.DB.Url=jdbc:sqlite:/db/burst.sqlite
+DEV.DB.Username=
+DEV.DB.Password=

--- a/conf/logging-docker.properties
+++ b/conf/logging-docker.properties
@@ -1,0 +1,2 @@
+# Log to console
+handlers = java.util.logging.ConsoleHandler


### PR DESCRIPTION
`conf/logging-docker.properties ` - disable log to file in docker: https://github.com/burst-apps-team/burstcoin/issues/327
All logs in stout.

I've created two Dockerfile, one for testnet, second for mainnet. I'd like to have one Dockerfile, but they have a diffrent expose ports, so looks like better have two diffrent Dockerfile than one.

Now all configurations in repo, with pre-configured examples.

User/developer can run mainnet/testnet without reading documentation.

By default, it uses sqlite db.

You can change DB backend:

```
docker build -f Dockerfile.testnet --build-arg CUSTOM_CONF=brs.properties.mariadb .
docker build -f Dockerfile.mainet --build-arg CUSTOM_CONF=brs.properties.h2 .
```

If you need your own settings, you create `conf/brs.properties` (it ignored in git) and build with that config:

`docker build -f Dockerfile.mainet --build-arg CUSTOM_CONF=brs.properties .`

`VOLUME ["/conf", "/db"]` - `/db` for mariadb is not needed, but nothing serious if it will, I think better than have many dockerfiles with minor changes. User who will use mariadb should be more experienced.

`conf/brs-default.properties` - I noticed that in all configurations `API.Listen = 0.0.0.0` and `API.allowed = *` setted, then why not use it by default? Also `API.V2.Listen = 0.0.0.0` setted already for all.

P.S. one comment says: `# Set to 0.0.0.0 to allow the API server to accept requests from all network interfaces.` second `# Set to "all" to allow the API server to accept requests from all network interfaces.` it will be nice to make they are ident

`conf/brs-default-testnet.properties` - it's copy of `conf/brs-default.properties` with applied changes from https://github.com/burst-apps-team/burstcoin/releases/download/v3.0.0-alpha5/brs-testnet.properties

`conf/brs.properties.*` - contain only DB configurations.

As you can see, need to configure both db variables for mainnet and testnet, because they are in diffrent variables. 
First, I'd like to ask what do you think about that all, let's discuss if you this think more convenient to use. 
Second, I'd like to get rid duplicates these variables: DEV.API.Port DEV.API.V2.Port DEV.DB.Url DEV.DB.Username DEV.DB.Password DEV.P2P.BootstrapPeers DEV.P2P.rebroadcastTo

For example, `Props.DEV_P2P_BOOTSTRAP_PEERS` and `Props.P2P_BOOTSTRAP_PEERS` they are ident by logic, but if testnet you must define one, if not - other variable. Also code, imho, will more clean:
``` kotlin
val wellKnownPeersList = dp.propertyService.get(if (dp.propertyService.get(Props.DEV_TESTNET)) Props.DEV_P2P_BOOTSTRAP_PEERS else Props.P2P_BOOTSTRAP_PEERS)
```
``` kotlin
val wellKnownPeersList = dp.propertyService.get(Props.P2P_BOOTSTRAP_PEERS)
```
Further will be possible remove # testnet DEV.DB.* sections from configs. I'll do if you'll like that idea.

TODO: make changes readme
