### PR TITLE
Optimize indirect incoming, one multiple rows insert

### DIFF
--- a/src/main/kotlin/brs/db/sql/SqlIndirectIncomingStore.kt
+++ b/src/main/kotlin/brs/db/sql/SqlIndirectIncomingStore.kt
@@ -50,7 +50,7 @@ internal class SqlIndirectIncomingStore(private val dp: DependencyProvider) : In
                 INDIRECT_INCOMING.TRANSACTION_ID,
                 INDIRECT_INCOMING.HEIGHT
             )
-            indirectIncomings.toTypedArray().map { entity ->
+            indirectIncomings.toList().map { entity ->
                 insertQuery = insertQuery.values(
                     entity.accountId,
                     entity.transactionId,

--- a/src/main/kotlin/brs/db/sql/SqlIndirectIncomingStore.kt
+++ b/src/main/kotlin/brs/db/sql/SqlIndirectIncomingStore.kt
@@ -47,7 +47,7 @@ internal class SqlIndirectIncomingStore(private val dp: DependencyProvider) : In
                     INDIRECT_INCOMING.TRANSACTION_ID,
                     INDIRECT_INCOMING.HEIGHT
                 )
-                entities.map { entity ->
+                entities.forEach { entity ->
                     insertQuery = insertQuery.values(
                         entity.accountId,
                         entity.transactionId,


### PR DESCRIPTION
Part of #350 was a bit improved speed on blocks with a lot multiout transactions.

![image](https://user-images.githubusercontent.com/5445357/75626516-bc75a680-5bfa-11ea-8b2b-23194b3edf89.png)

One insert instead many queries.

https://www.jooq.org/doc/3.13/manual/sql-building/sql-statements/insert-statement/insert-values/
Just an interesting note: https://stackoverflow.com/questions/45274242/jooq-batch-record-insert

