### PR TITLE
Fast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ def jUnit4Version = "4.13"
 def mockkVersion = "1.9.3"
 def javaxAnnotationVersion = "1.3.2"
 def kotlinArgParserVersion = "2.0.7"
+def netLayerVersion = "0.6.7"
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
@@ -113,6 +114,7 @@ dependencies {
     implementation "org.ehcache:ehcache:$ehCacheVersion"
     implementation "javax.annotation:javax.annotation-api:$javaxAnnotationVersion"
     implementation "com.xenomachina:kotlin-argparser:$kotlinArgParserVersion"
+    implementation "com.github.JesusMcCloud.netlayer:tor.native:$netLayerVersion"
 
     testImplementation "junit:junit:$jUnit4Version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$jUnit5Version"

--- a/src/main/kotlin/brs/Burst.kt
+++ b/src/main/kotlin/brs/Burst.kt
@@ -211,7 +211,7 @@ LS: ${LibShabal.LOAD_ERROR?.toString() ?: LibShabal.VERSION}
     }
 
     companion object {
-        val VERSION = Version.parse("v3.0.0-dev")
+        val VERSION = Version.parse("v3.0.0-alpha5")
         const val APPLICATION = "BRS"
         private const val DEFAULT_PROPERTIES_NAME = "brs-default.properties"
 

--- a/src/main/kotlin/brs/api/http/common/Parameters.kt
+++ b/src/main/kotlin/brs/api/http/common/Parameters.kt
@@ -81,6 +81,7 @@ object Parameters {
     const val NUM_BLOCKS_PARAMETER = "numBlocks"
     const val BLOCK_PARAMETER = "block"
     const val INCLUDE_COUNTS_PARAMETER = "includeCounts"
+    const val INCLUDE_EFFECTIVE_BALANCE_PARAMETER = "includeEffectiveBalance"
     const val DEADLINE_PARAMETER = "deadline"
     const val REFERENCED_TRANSACTION_FULL_HASH_PARAMETER = "referencedTransactionFullHash"
     const val REFERENCED_TRANSACTION_PARAMETER = "referencedTransaction"

--- a/src/main/kotlin/brs/objects/Props.kt
+++ b/src/main/kotlin/brs/objects/Props.kt
@@ -103,6 +103,9 @@ object Props {
 
     val API_LISTEN = Prop("API.Listen", "127.0.0.1")
     val API_PORT = Prop("API.Port", 8125)
+    val API_TOR = Prop("API.Tor", false)
+    val API_TOR_PORT = Prop("API.TorPort", 1025)
+    val API_TOR_FOLDER = Prop("API.TorFolder", "brs-tor")
     val API_V2_LISTEN = Prop("API.V2.Listen", "0.0.0.0")
     val API_V2_PORT = Prop("API.V2.Port", 8121)
 

--- a/src/main/kotlin/brs/objects/Props.kt
+++ b/src/main/kotlin/brs/objects/Props.kt
@@ -28,6 +28,12 @@ object Props {
     val DEV_PRE_DYMAXION_BLOCK_HEIGHT = Prop("DEV.preDymaxion.startBlock", -1)
     val DEV_POC2_BLOCK_HEIGHT = Prop("DEV.poc2.startBlock", -1)
     val DEV_NEXT_FORK_BLOCK_HEIGHT = Prop("DEV.nextFork.startBlock", -1)
+	
+	// Checkpoint block for low CPU usage when syncing an empty database
+	val BRS_CHECKPOINT_HEIGHT = Prop("brs.checkPointHeight", 730_000)
+	val BRS_CHECKPOINT_HASH = Prop("brs.checkPointPrevHash", "7c9f8eb553ae1c47cb8960847f6ae672a9923d9c0c4c13a2e23a430e1099a5bc")
+	val DEV_CHECKPOINT_HEIGHT = Prop("DEV.checkPointHeight", 150_000)
+	val DEV_CHECKPOINT_HASH = Prop("DEV.checkPointPrevHash", "c99b807f4bff0d439375d083e2e04c465e96ec36d85092e8faba7b9a19534b94")
 
     // GPU options
     val GPU_ACCELERATION = Prop("GPU.Acceleration", false)
@@ -157,4 +163,5 @@ object Props {
     val ALLOW_OTHER_SOLO_MINERS = Prop("AllowOtherSoloMiners", true)
 
     val NUM_PRE_VERIFIER_THREADS = Prop("PreVerifier.NumberOfInstances", 0)
+    val MAX_CACHED_ENTITIES = Prop("MaxCachedEntities", 65536)
 }

--- a/src/main/kotlin/brs/services/impl/ParameterServiceImpl.kt
+++ b/src/main/kotlin/brs/services/impl/ParameterServiceImpl.kt
@@ -75,7 +75,7 @@ class ParameterServiceImpl(private val dp: DependencyProvider) : ParameterServic
             return dp.accountService.getAccount(accountId.parseAccountId())
                 ?: throw ParameterException(UNKNOWN_ACCOUNT)
         } catch (e: Exception) {
-            throw ParameterException(INCORRECT_ACCOUNT)
+            throw ParameterException(UNKNOWN_ACCOUNT)
         }
     }
 

--- a/src/main/kotlin/brs/services/impl/PeerServiceImpl.kt
+++ b/src/main/kotlin/brs/services/impl/PeerServiceImpl.kt
@@ -610,7 +610,7 @@ class PeerServiceImpl(private val dp: DependencyProvider) : PeerService {
             when {
                 !beingProcessed.contains(peer) -> {
                     beingProcessed.add(peer)
-                    dp.taskSchedulerService.run { feedPeer(peer, foodDispenser, doneFeedingLog) }
+                    dp.taskSchedulerService.async(TaskType.IO) { feedPeer(peer, foodDispenser, doneFeedingLog) }
                 }
                 !processingQueue.contains(peer) -> processingQueue.add(peer)
             }

--- a/src/main/kotlin/brs/services/impl/TransactionProcessorServiceImpl.kt
+++ b/src/main/kotlin/brs/services/impl/TransactionProcessorServiceImpl.kt
@@ -108,14 +108,15 @@ class TransactionProcessorServiceImpl(private val dp: DependencyProvider) : Tran
         if (!transaction.verifySignature()) {
             throw BurstException.NotValidException("Transaction signature verification failed")
         }
-        val processedTransactions = processTransactions(listOf(transaction), null)
-        if (dp.transactionDb.hasTransaction(transaction.id)) {
-            logger.safeDebug { "Transaction ${transaction.stringId} already in blockchain, will not broadcast again" }
-            return null
-        }
 
         if (dp.unconfirmedTransactionService.exists(transaction.id)) {
             logger.safeDebug { "Transaction ${transaction.stringId} already in unconfirmed pool, will not broadcast again" }
+            return null
+        }
+
+        val processedTransactions = processTransactions(listOf(transaction), null)
+        if (dp.transactionDb.hasTransaction(transaction.id)) {
+            logger.safeDebug { "Transaction ${transaction.stringId} already in blockchain, will not broadcast again" }
             return null
         }
 


### PR DESCRIPTION
Small modification to reduce CPU usage during sync of an empty database. This is actually to be applied over alpha5, as develop is apparently broken right now (refuse some multi-out transactions around block 5000 on testnet).

On my experience using this, CPU usage stays low and blocks/s is around 3 times faster.