### PR TITLE
New API get call getAccountAssets

### DIFF
--- a/src/brs/http/APIServlet.java
+++ b/src/brs/http/APIServlet.java
@@ -70,6 +70,7 @@ public final class APIServlet extends HttpServlet {
     map.put("getAccountTransactionIds", new GetAccountTransactionIds(parameterService, blockchain));
     map.put("getAccountTransactions", new GetAccountTransactions(parameterService, blockchain));
     map.put("getAccountLessors", new GetAccountLessors(parameterService, blockchain));
+    map.put("getAccountAssets", new GetAccountAssets(parameterService, accountService));
     map.put("sellAlias", new SellAlias(parameterService, blockchain, apiTransactionManager));
     map.put("buyAlias", new BuyAlias(parameterService, blockchain, aliasService, apiTransactionManager));
     map.put("getAlias", new GetAlias(parameterService, aliasService));

--- a/src/brs/http/GetAccount.java
+++ b/src/brs/http/GetAccount.java
@@ -18,7 +18,7 @@ public final class GetAccount extends APIServlet.JsonRequestHandler {
 
   private final ParameterService parameterService;
   private final AccountService accountService;
-  private final String depreciationMessage = "For account assets use getAccountAssets. This will be removed after next hardfork";
+  private final String deprecationMessage = "For account assets use getAccountAssets. This will be removed in V3.0";
 
   GetAccount(ParameterService parameterService, AccountService accountService) {
     super(new APITag[] {APITag.ACCOUNTS}, ACCOUNT_PARAMETER);
@@ -60,7 +60,7 @@ public final class GetAccount extends APIServlet.JsonRequestHandler {
     }
 
     if (assetBalances.size() > 0 || unconfirmedAssetBalances.size() > 0) {
-      response.addProperty(DEPRECIATION_RESPONSE, depreciationMessage);
+      response.addProperty(DEPRECATION_RESPONSE, deprecationMessage);
     }
 
     if (assetBalances.size() > 0) {

--- a/src/brs/http/GetAccount.java
+++ b/src/brs/http/GetAccount.java
@@ -18,7 +18,7 @@ public final class GetAccount extends APIServlet.JsonRequestHandler {
 
   private final ParameterService parameterService;
   private final AccountService accountService;
-  private final String depreciationMessage = "For account assets use getAccountAssets. This will be removed after net hardfork";
+  private final String depreciationMessage = "For account assets use getAccountAssets. This will be removed after next hardfork";
 
   GetAccount(ParameterService parameterService, AccountService accountService) {
     super(new APITag[] {APITag.ACCOUNTS}, ACCOUNT_PARAMETER);

--- a/src/brs/http/GetAccount.java
+++ b/src/brs/http/GetAccount.java
@@ -18,6 +18,7 @@ public final class GetAccount extends APIServlet.JsonRequestHandler {
 
   private final ParameterService parameterService;
   private final AccountService accountService;
+  private final String depreciationMessage = "For account assets use getAccountAssets. This will be removed after net hardfork";
 
   GetAccount(ParameterService parameterService, AccountService accountService) {
     super(new APITag[] {APITag.ACCOUNTS}, ACCOUNT_PARAMETER);
@@ -43,6 +44,7 @@ public final class GetAccount extends APIServlet.JsonRequestHandler {
       response.addProperty(DESCRIPTION_RESPONSE, account.getDescription());
     }
 
+    //Assets logic moved to GetAccountAssets. Remove this in V3
     JsonArray assetBalances = new JsonArray();
     JsonArray unconfirmedAssetBalances = new JsonArray();
 
@@ -55,6 +57,10 @@ public final class GetAccount extends APIServlet.JsonRequestHandler {
       unconfirmedAssetBalance.addProperty(ASSET_RESPONSE, Convert.toUnsignedLong(accountAsset.getAssetId()));
       unconfirmedAssetBalance.addProperty(UNCONFIRMED_BALANCE_QNT_RESPONSE, String.valueOf(accountAsset.getUnconfirmedQuantityQNT()));
       unconfirmedAssetBalances.add(unconfirmedAssetBalance);
+    }
+
+    if (assetBalances.size() > 0 || unconfirmedAssetBalances.size() > 0) {
+      response.addProperty(DEPRECIATION_RESPONSE, depreciationMessage);
     }
 
     if (assetBalances.size() > 0) {

--- a/src/brs/http/GetAccountAssets.java
+++ b/src/brs/http/GetAccountAssets.java
@@ -11,7 +11,7 @@ import com.google.gson.JsonObject;
 
 import javax.servlet.http.HttpServletRequest;
 
-import static brs.http.common.Parameters.ACCOUNT_PARAMETER;
+import static brs.http.common.Parameters.*;
 import static brs.http.common.ResultFields.*;
 
 public final class GetAccountAssets extends APIServlet.JsonRequestHandler {
@@ -20,7 +20,7 @@ public final class GetAccountAssets extends APIServlet.JsonRequestHandler {
     private final AccountService accountService;
 
     GetAccountAssets(ParameterService parameterService, AccountService accountService) {
-        super(new APITag[] {APITag.ACCOUNTS}, ACCOUNT_PARAMETER);
+        super(new APITag[] {APITag.ACCOUNTS}, ACCOUNT_PARAMETER, FIRST_INDEX_PARAMETER, LAST_INDEX_PARAMETER);
         this.parameterService = parameterService;
         this.accountService = accountService;
     }
@@ -30,12 +30,15 @@ public final class GetAccountAssets extends APIServlet.JsonRequestHandler {
 
         Account account = parameterService.getAccount(req);
 
+        int firstIndex = ParameterParser.getFirstIndex(req);
+        int lastIndex = ParameterParser.getLastIndex(req);
+
         JsonObject response = new JsonObject();
 
         JsonArray assetBalances = new JsonArray();
         JsonArray unconfirmedAssetBalances = new JsonArray();
 
-        for (Account.AccountAsset accountAsset : accountService.getAssets(account.getId(), 0, -1)) {
+        for (Account.AccountAsset accountAsset : accountService.getAssets(account.getId(), firstIndex, lastIndex)) {
             JsonObject assetBalance = new JsonObject();
             assetBalance.addProperty(ASSET_RESPONSE, Convert.toUnsignedLong(accountAsset.getAssetId()));
             assetBalance.addProperty(BALANCE_QNT_RESPONSE, String.valueOf(accountAsset.getQuantityQNT()));

--- a/src/brs/http/GetAccountAssets.java
+++ b/src/brs/http/GetAccountAssets.java
@@ -1,0 +1,54 @@
+package brs.http;
+
+import brs.Account;
+import brs.BurstException;
+import brs.services.AccountService;
+import brs.services.ParameterService;
+import brs.util.Convert;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static brs.http.common.Parameters.ACCOUNT_PARAMETER;
+import static brs.http.common.ResultFields.*;
+
+public final class GetAccountAssets extends APIServlet.JsonRequestHandler {
+
+    private final ParameterService parameterService;
+    private final AccountService accountService;
+
+    GetAccountAssets(ParameterService parameterService, AccountService accountService) {
+        super(new APITag[] {APITag.ACCOUNTS}, ACCOUNT_PARAMETER);
+        this.parameterService = parameterService;
+        this.accountService = accountService;
+    }
+
+    @Override
+    JsonElement processRequest(HttpServletRequest req) throws BurstException {
+
+        Account account = parameterService.getAccount(req);
+
+        JsonObject response = new JsonObject();
+
+        JsonArray assetBalances = new JsonArray();
+        JsonArray unconfirmedAssetBalances = new JsonArray();
+
+        for (Account.AccountAsset accountAsset : accountService.getAssets(account.getId(), 0, -1)) {
+            JsonObject assetBalance = new JsonObject();
+            assetBalance.addProperty(ASSET_RESPONSE, Convert.toUnsignedLong(accountAsset.getAssetId()));
+            assetBalance.addProperty(BALANCE_QNT_RESPONSE, String.valueOf(accountAsset.getQuantityQNT()));
+            assetBalances.add(assetBalance);
+            JsonObject unconfirmedAssetBalance = new JsonObject();
+            unconfirmedAssetBalance.addProperty(ASSET_RESPONSE, Convert.toUnsignedLong(accountAsset.getAssetId()));
+            unconfirmedAssetBalance.addProperty(UNCONFIRMED_BALANCE_QNT_RESPONSE, String.valueOf(accountAsset.getUnconfirmedQuantityQNT()));
+            unconfirmedAssetBalances.add(unconfirmedAssetBalance);
+        }
+
+        response.add(ASSET_BALANCES_RESPONSE, assetBalances);
+        response.add(UNCONFIRMED_ASSET_BALANCES_RESPONSE, unconfirmedAssetBalances);
+
+        return response;
+    }
+}

--- a/src/brs/http/common/ResultFields.java
+++ b/src/brs/http/common/ResultFields.java
@@ -7,6 +7,7 @@ public class ResultFields {
   public static final String ERROR_CODE_RESPONSE = "errorCode";
   public static final String ERROR_DESCRIPTION_RESPONSE = "errorDescription";
   public static final String DECRYPTED_MESSAGE_RESPONSE = "decryptedMessage";
+  public static final String DEPRECIATION_RESPONSE = "depreciation";
   public static final String BALANCE_NQT_RESPONSE = "balanceNQT";
   public static final String BALANCE_QNT_RESPONSE = "balanceQNT";
   public static final String UNCONFIRMED_BALANCE_NQT_RESPONSE = "unconfirmedBalanceNQT";

--- a/src/brs/http/common/ResultFields.java
+++ b/src/brs/http/common/ResultFields.java
@@ -7,7 +7,7 @@ public class ResultFields {
   public static final String ERROR_CODE_RESPONSE = "errorCode";
   public static final String ERROR_DESCRIPTION_RESPONSE = "errorDescription";
   public static final String DECRYPTED_MESSAGE_RESPONSE = "decryptedMessage";
-  public static final String DEPRECIATION_RESPONSE = "depreciation";
+  public static final String DEPRECATION_RESPONSE = "deprecation";
   public static final String BALANCE_NQT_RESPONSE = "balanceNQT";
   public static final String BALANCE_QNT_RESPONSE = "balanceQNT";
   public static final String UNCONFIRMED_BALANCE_NQT_RESPONSE = "unconfirmedBalanceNQT";


### PR DESCRIPTION
If account has assets getAccout api call returns array of assets. This behavior only for assets ( transactions, AT, subscriptions has own api call and are not returned in getAccount). So I think assets must be moved to separate API call getAccountAssets. 

I think then changing API calls it is good practice  to give some time for API users to adjust and message them, so I created depreciation message.

In this pull there is no GRPC implementation 