### PR TITLE
Polishing 2.5 with feedback from node operators

### DIFF
--- a/conf/brs-default.properties
+++ b/conf/brs-default.properties
@@ -252,7 +252,7 @@ GPU.HashesPerBatch = 1000
 # number of unverified transactions in cache before GPU verification starts.
 GPU.UnverifiedQueue = 1000
 
-# Uncomment this to limit the number of cpu cores the wallet sees. Default is all available.
+# Uncomment this to limit the number of cpu cores the wallet sees. Default is half available.
 # CPU.NumCores = 4
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,7 @@
                 <jar>burst.jar</jar>
                 <jre>
                   <minVersion>1.8.0</minVersion>
+                  <runtimeBits>64</runtimeBits>
                 </jre>
                 <versionInfo>
                   <fileVersion>${project.version}.0</fileVersion>

--- a/src/brs/peer/Peers.java
+++ b/src/brs/peer/Peers.java
@@ -826,7 +826,8 @@ public final class Peers {
       if(response != null && response.get("error") == null) {
         doneFeedingLog.accept(peer, transactionsToSend);
       } else {
-        logger.warn("Error feeding {} transactions: {} error: {}", peer.getPeerAddress(), transactionsToSend.stream().map(Transaction::getId).collect(Collectors.toList()), response);
+    	if(logger.isDebugEnabled())
+          logger.debug("Error feeding {} transactions: {} error: {}", peer.getPeerAddress(), transactionsToSend.stream().map(Transaction::getId).collect(Collectors.toList()), response);
       }
     } else {
       logger.trace("No need to feed {}", peer.getPeerAddress());

--- a/src/brs/util/ThreadPool.java
+++ b/src/brs/util/ThreadPool.java
@@ -90,9 +90,10 @@ public final class ThreadPool {
 
     int cores = propertyService.getInt(Props.CPU_NUM_CORES);
     if (cores <= 0) {
-        logger.warn("Cannot use 0 cores - defaulting to all available");
-        cores = Runtime.getRuntime().availableProcessors();
-      }
+        cores = Runtime.getRuntime().availableProcessors() / 2;
+        cores = Math.max(1, cores);
+    }
+    logger.info("Using {} cores", cores);
     int totalThreads = backgroundJobs.size() + backgroundJobsCores.size() * cores;
     logger.debug("Starting {} background jobs", totalThreads);
     scheduledThreadPool = Executors.newScheduledThreadPool(totalThreads);


### PR DESCRIPTION
- Require 64 bit Java for Windows (apparently solves all the H2 issues)
- Some messages spamming logs now only on debug level
- Do not use all cores by default, using half (minimum 1)