### PR TITLE
Limit by total length and not 100 blocks.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>burstcoin</groupId>
   <artifactId>burstcoin</artifactId>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
   <name>Burstcoin Reference Software</name>
   <url>https://github.com/burst-apps-team/burstcoin</url>
 

--- a/src/brs/Burst.java
+++ b/src/brs/Burst.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
 
 public final class Burst {
 
-  public static final Version VERSION = Version.parse("v2.5.0");
+  public static final Version VERSION = Version.parse("v2.5.1");
 
   public static final String APPLICATION = "BRS";
 

--- a/src/brs/peer/GetNextBlocks.java
+++ b/src/brs/peer/GetNextBlocks.java
@@ -16,8 +16,8 @@ import java.util.List;
 final class GetNextBlocks implements PeerServlet.PeerRequestHandler {
 
   private final Blockchain blockchain;
-  private final int maxLength = 1048576;
-  private final int maxBlocks = 1440 / 2; // maxRollback must be at least 1440 and we are using half of that
+  private static final int MAX_LENGHT = 1048576;
+  private static final int MAX_BLOCKS = 1440 / 2; // maxRollback must be at least 1440 and we are using half of that
 
   GetNextBlocks(Blockchain blockchain) {
     this.blockchain = blockchain;
@@ -33,16 +33,17 @@ final class GetNextBlocks implements PeerServlet.PeerRequestHandler {
     int totalLength = 0;
     long blockId = Convert.parseUnsignedLong(JSON.getAsString(request.get("blockId")));
     
-    while(totalLength < maxLength && nextBlocks.size() < maxBlocks) {
+    while(totalLength < MAX_LENGHT && nextBlocks.size() < MAX_BLOCKS) {
       Collection<? extends Block> blocks = blockchain.getBlocksAfter(blockId, 100);
-      if (blocks.size() == 0)
+      if (blocks.isEmpty()) {
     	break;
+      }
       
       for (Block block : blocks) {
         int length = Constants.BLOCK_HEADER_LENGTH + block.getPayloadLength();
         totalLength += length;
         nextBlocks.add(block);
-        if (totalLength >= maxLength || nextBlocks.size() >= maxBlocks) {
+        if (totalLength >= MAX_LENGHT || nextBlocks.size() >= MAX_BLOCKS) {
           break;
         }
         blockId = block.getId();

--- a/src/brs/peer/GetNextBlocks.java
+++ b/src/brs/peer/GetNextBlocks.java
@@ -17,7 +17,7 @@ final class GetNextBlocks implements PeerServlet.PeerRequestHandler {
 
   private final Blockchain blockchain;
   private final int maxLength = 1048576;
-  private final int maxBlocks = Constants.MAX_ROLLBACK / 2;
+  private final int maxBlocks = 1440 / 2; // maxRollback must be at least 1440 and we are using half of that
 
   GetNextBlocks(Blockchain blockchain) {
     this.blockchain = blockchain;

--- a/src/brs/peer/GetNextBlocks.java
+++ b/src/brs/peer/GetNextBlocks.java
@@ -33,27 +33,20 @@ final class GetNextBlocks implements PeerServlet.PeerRequestHandler {
     int totalLength = 0;
     long blockId = Convert.parseUnsignedLong(JSON.getAsString(request.get("blockId")));
     
-    while(true) {
+    while(totalLength < maxLength && nextBlocks.size() < maxBlocks) {
       Collection<? extends Block> blocks = blockchain.getBlocksAfter(blockId, 100);
       if (blocks.size() == 0)
     	break;
       
-      int length = 0;
       for (Block block : blocks) {
-        length = Constants.BLOCK_HEADER_LENGTH + block.getPayloadLength();
-        if (totalLength + length > maxLength) {
-          break;
-        }
+        int length = Constants.BLOCK_HEADER_LENGTH + block.getPayloadLength();
         totalLength += length;
         nextBlocks.add(block);
-        if (nextBlocks.size() >= maxBlocks)
+        if (totalLength >= maxLength || nextBlocks.size() >= maxBlocks) {
           break;
+        }
         blockId = block.getId();
-      }
-      
-      if (totalLength + length > maxLength || nextBlocks.size() >= maxBlocks) {
-    	break;
-      }
+      }      
     }
 
     JsonArray nextBlocksArray = new JsonArray();


### PR DESCRIPTION
The size limit per request is the same as before, but not capped at 100 blocks anymore.

Testing this with a single node very far away from me gives this results (would be less than 3h from empty):
![image](https://user-images.githubusercontent.com/31958515/81863824-2affaa80-9542-11ea-8002-25c06b5b427a.png)
